### PR TITLE
Add Sentry test route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -5,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import SentryTest from "./pages/SentryTest";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +18,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/sentry-test" element={<SentryTest />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/SentryTest.tsx
+++ b/src/pages/SentryTest.tsx
@@ -1,0 +1,22 @@
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+const SentryTest = () => {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <h1 className="text-2xl font-bold mb-6">Sentry Error Test Page</h1>
+      <Button
+        type="button"
+        variant="destructive"
+        onClick={() => {
+          throw new Error("Sentry Test Error");
+        }}
+      >
+        Break the world
+      </Button>
+    </div>
+  );
+};
+
+export default SentryTest;


### PR DESCRIPTION
Adds a route at /sentry-test that throws an error when a button is clicked, for testing Sentry integration.